### PR TITLE
Update skilldesc_text.txt

### DIFF
--- a/Text/skilldesc_text.txt
+++ b/Text/skilldesc_text.txt
@@ -279,7 +279,7 @@ Impale: Deal 4x damage.[N]
 (Skill % activation)[X]
 
 ## SD_Colossus
-Colossus: Triples Strength.[N]
+Colossus: Triples Attack.[N]
 (Skill % activation)[X]
 
 ## SD_RallyStr
@@ -397,8 +397,8 @@ Lily's Poise: Adjacent allies gain[N]
 +1/-3 damage dealt/received.[X]
 
 ## SD_Expertise
-Expertise: Reduce bonus damage[N]
-from critical hits by 50%.[X]
+Expertise: Receive double damage[N]
+from crits instead of triple.[X]
 
 ## SD_Celerity
 Celerity: Movement +2.[X]
@@ -717,7 +717,7 @@ Skill Activations.[X]
 
 ## SD_Axefaith
 Axefaith: Axes can't lose durability, and[N]
-grants +Luck*1.5 Hit when wielding axes.[X]
+grants +(Luck*1.5) Hit when wielding axes.[X]
 
 ## SD_ArmorMarch
 Armor March: At start of turn, if unit[N]
@@ -778,13 +778,13 @@ Hex: -15 avoid to all[N]
 adjacent enemies.[X]
 
 ## SD_Barricade
-Barricade: Damage taken is[N]
-halved after first being struck.[X]
+Barricade: Take half damage from[N]
+all hits except the first one.[X]
 
 ## SD_BarricadePlus
-Barricade+: In combat, damage[N]
-recieved equals half of the[N]
-damage when struck last.[X]
+Barricade+: Receive 1/2 damage[N]
+from the 2nd hit, 1/4 from the[N]
+3rd, and 1/8 from the 4th.[X]
 
 ## SD_PointBlank
 Point Blank: Minimum range of[N]
@@ -820,7 +820,8 @@ W. Weight, +2 dmg, +15% hit, +5% crit.[X]
 
 ## SD_Outrider
 Outrider: Take -1 damage and[N]
-gain +3% crit per space moved.[X]
+gain +3% crit per space moved.[N]
+Bonuses disappear on enemy phase.[X]
 
 ## SD_HeavyStrikes
 Heavy Strikes: Add weapon[N]
@@ -828,7 +829,8 @@ weight to critical chance.[X]
 
 ## SD_Charge
 Charge: Gain +1 damage for[N]
-every two squares moved.[X]
+every two squares moved.[N]
+Bonus disappears on enemy phase.[X]
 
 ## SD_Infiltrator
 Infiltrator: If within 2 spaces[N]
@@ -900,7 +902,7 @@ Blossom: 2x growth rates,[N]
 but 1/2 exp gain.[X]
 
 ## SD_Aptitude
-Aptitude: +20% to[N]
+Aptitude: +20 to[N]
 all growth rates.[X]
 
 ## SD_QuickRiposte


### PR DESCRIPTION
Fixed the description for Colossus and clarified other skill descriptions. Also removed the percentage sign from the Aptitude desc in case someone thinks it's multiplying growths by 1.2.